### PR TITLE
コードの可読性を上げるため空行の調整

### DIFF
--- a/src/main/java/com/raisetech/worldCup2022/ParticipatingCountry.java
+++ b/src/main/java/com/raisetech/worldCup2022/ParticipatingCountry.java
@@ -6,12 +6,10 @@ public class ParticipatingCountry {
     private  String name;
     private  String continent;
 
-
     public ParticipatingCountry(int id, String name, String continent) {
         this.id = id;
         this.name = name;
         this.continent = continent;
-
     }
 
     public int getId() {

--- a/src/main/java/com/raisetech/worldCup2022/ParticipatingCountryController.java
+++ b/src/main/java/com/raisetech/worldCup2022/ParticipatingCountryController.java
@@ -10,17 +10,14 @@ import java.util.Optional;
 public class ParticipatingCountryController {
 
     private final ParticipatingCountryMapper participatingCountryMapper;
+
     public ParticipatingCountryController(ParticipatingCountryMapper participatingCountryMapper) {
         this.participatingCountryMapper = participatingCountryMapper;
     }
 
     @GetMapping("/participatingCountry/{id}")
-
     public Optional<ParticipatingCountry> selectNumber(@PathVariable("id")int id) {
         return participatingCountryMapper.findById(id);
     }
-
-
-
 
 }

--- a/src/main/java/com/raisetech/worldCup2022/ParticipatingCountryMapper.java
+++ b/src/main/java/com/raisetech/worldCup2022/ParticipatingCountryMapper.java
@@ -15,10 +15,4 @@ public interface ParticipatingCountryMapper {
     @Select("SELECT * FROM participatingCountry WHERE id = #{id}")
     Optional<ParticipatingCountry> findById(int id);
 
-
-
-
-
-
-
 }


### PR DESCRIPTION
## 空行の調整

- コンストラクタ文と}の間の空行をなくす。
<img width="463" alt="スクリーンショット 2023-06-28 15 02 39" src="https://github.com/tatsuya-d/WorldCup2022/assets/133928911/e80fb89e-28ea-41da-ab39-c951356b0908">


- フィールドとコンストラクタを区別するために1行あける。
<img width="1470" alt="スクリーンショット 2023-06-28 14 51 18" src="https://github.com/tatsuya-d/WorldCup2022/assets/133928911/286d7623-1e1d-49c5-94c2-cd93ea14b060">

- @GetMappingのアノテーションとselectNumberメソッドはセットなので空行をなくす。
<img width="687" alt="スクリーンショット 2023-06-28 15 01 30" src="https://github.com/tatsuya-d/WorldCup2022/assets/133928911/f0baf3e0-0fca-4354-abaf-8bd0b8facb52">

- Mapperインターフェースのメソッド終わりに空行が2行以上あるのをなくす。
<img width="657" alt="スクリーンショット 2023-06-28 15 05 12" src="https://github.com/tatsuya-d/WorldCup2022/assets/133928911/80db53d9-9e8a-4b19-91ee-05a5150b4e9f">

- ParticipatingCountryクラスのフィールドとコンストラクタの空行を2行から1にする。
<img width="641" alt="スクリーンショット 2023-06-28 15 07 08" src="https://github.com/tatsuya-d/WorldCup2022/assets/133928911/9c3a9578-0f4b-417b-aaa7-dbd226c2d047">

- コントローラークラスの最後の波括弧の空行を間1行にする。
<img width="821" alt="スクリーンショット 2023-06-28 15 10 13" src="https://github.com/tatsuya-d/WorldCup2022/assets/133928911/e7a4c1af-24d5-4f34-b643-c3e44a392afc">

- 



